### PR TITLE
Cap ipywidgets<8 and simplify installation directly from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,15 @@ Thanks!
 
 ## Install
 ---------
-- ` git clone https://github.com/johnomernik/qgrid`
+In one command:
+
+`pip install git+https://github.com/JohnOmernik/qgrid  https://github.com/JohnOmernik/qgrid/raw/main/qgrid2-1.1.3-py3-none-any.whl`
+
+..or install from sources (in develop mode with `-e`):
+
+- `git clone https://github.com/johnomernik/qgrid --depth=1`
 - `cd qgrid`
-- `python setup.py install`
+- `pip install -e .`
 - `pip install qgrid2-1.1.3-py3-none-any.whl`
 - `cd ..`
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ At this point, it worked for me with:
 
 - Python 3.9
 - JupyterLab 3.2.1
-- ipywidgets 7.6.5
+- ipywidgets 7.6.5 <8
 
 Note: I did not require Node JS to get this working, just the commands above made it work as I prebuilt the extension. 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel"]  # PEP 508 specifications.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 notebook>=4.0.0
 pandas>=0.18.0
-ipywidgets>=7.0.0
+ipywidgets>=7,<8


### PR DESCRIPTION
+ Discovered that the current codebase fails with `ipywidgets-8.x.x`, as described in #9.
+ Revamped installations instructions to work directly from GitHub
  (where the project is hosted).
+ Added a `pyproject.toml` file to properly build wheel out of this project 
  (mute also a warning when installing directly from GitHub).